### PR TITLE
feat(types): centralized types architecture

### DIFF
--- a/__tests__/integration/user-router.test.ts
+++ b/__tests__/integration/user-router.test.ts
@@ -10,9 +10,10 @@
  * - Test the core logic that would be executed by tRPC procedures
  */
 
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { UserRole, type User } from "@/types";
+import type { PrismaClient } from "@prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { mockDeep, mockReset } from "vitest-mock-extended";
-import type { PrismaClient, User } from "@prisma/client";
 
 // Create mocked Prisma client
 const prismaMock = mockDeep<PrismaClient>();
@@ -31,7 +32,7 @@ const mockUser: User = {
   cvLatexUrl: null,
   cvFilename: null,
   cvUploadedAt: null,
-  role: "USER",
+  role: UserRole.USER,
   isTrusted: false,
   isVerified: false,
   image: null,

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -9,31 +9,12 @@
 
 import { prisma } from "@/lib/db";
 import { encryptToken } from "@/lib/social";
+import { type UserRole } from "@/types";
 import { PrismaAdapter } from "@auth/prisma-adapter";
-import type { UserRole } from "@prisma/client";
 import NextAuth from "next-auth";
 import GitHub from "next-auth/providers/github";
 import Google from "next-auth/providers/google";
 import LinkedIn from "next-auth/providers/linkedin";
-
-// Extend the built-in session types
-declare module "next-auth" {
-  interface Session {
-    user: {
-      id: string;
-      name?: string | null;
-      email?: string | null;
-      image?: string | null;
-      role: UserRole;
-      isTrusted: boolean;
-    };
-  }
-
-  interface User {
-    role?: UserRole;
-    isTrusted?: boolean;
-  }
-}
 
 export const { handlers, signIn, signOut, auth } = NextAuth({
   adapter: PrismaAdapter(prisma),
@@ -85,7 +66,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
      */
     async jwt({ token, user, trigger }) {
       // On sign in, add user data to token
-      if (user) {
+      if (user?.id) {
         token.id = user.id;
         token.role = user.role ?? "USER";
         token.isTrusted = user.isTrusted ?? false;

--- a/lib/hooks/index.ts
+++ b/lib/hooks/index.ts
@@ -12,10 +12,12 @@ export { useAnalyze } from "./useAnalyze";
 export type { JobAnalysisResult, ButtonState, UseAnalyzeReturn } from "./useAnalyze";
 
 export { useApplications } from "./useApplications";
+export type { UseApplicationsReturn } from "./useApplications";
+
+// Re-export application types from centralized types for convenience
 export type {
   Application,
   ApplicationStatus,
   CreateApplicationInput,
   ApplicationStats,
-  UseApplicationsReturn,
-} from "./useApplications";
+} from "@/types";

--- a/lib/hooks/useApplications.ts
+++ b/lib/hooks/useApplications.ts
@@ -12,51 +12,17 @@
 
 import { trpc } from "@/lib/trpc/client";
 import { getErrorMessage } from "@/lib/trpc/errors";
+import type {
+  Application,
+  ApplicationStats,
+  ApplicationStatus,
+  CreateApplicationInput,
+} from "@/types";
 import { useMemo } from "react";
 import type { ButtonState } from "./useAnalyze";
 
 /**
- * Application status options.
- */
-export type ApplicationStatus = "saved" | "applied" | "interviewing" | "offer" | "rejected";
-
-/**
- * Application data structure with string dates for UI.
- */
-export interface Application {
-  id: string;
-  company: string;
-  role: string;
-  matchScore: number;
-  status: string;
-  appliedAt: string | null;
-  createdAt: string;
-  notes: string | null;
-}
-
-/**
- * Input for creating a new application.
- */
-export interface CreateApplicationInput {
-  company: string;
-  role: string;
-  jobDescription: string;
-  matchScore: number;
-  analysis: string;
-  coverLetter: string;
-  status: ApplicationStatus;
-}
-
-/**
- * Application statistics.
- */
-export interface ApplicationStats {
-  total: number;
-  applied: number;
-  interviewing: number;
-  offers: number;
-  avgMatchScore: number;
-}
+ * Hook return types and input types come from `@/types`.
 
 /**
  * Return type for useApplications hook.

--- a/lib/trpc/routers/ux.ts
+++ b/lib/trpc/routers/ux.ts
@@ -9,7 +9,7 @@
  */
 
 import { adminProcedure, router } from "@/lib/trpc/init";
-import { type UxEffort, type UxSeverity, type UxStatus } from "@prisma/client";
+import type { UxEffort, UxSeverity, UxStatus } from "@/types";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 

--- a/prisma/seed-ux.ts
+++ b/prisma/seed-ux.ts
@@ -6,7 +6,8 @@
  * Run with: npx tsx prisma/seed-ux.ts
  */
 
-import { PrismaClient, UxSeverity, UxEffort, UxStatus } from "@prisma/client";
+import { PrismaClient } from "@prisma/client";
+import { UxEffort, UxSeverity, UxStatus } from "../types";
 
 const prisma = new PrismaClient();
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,6 +32,7 @@
   },
   "include": [
     "next-env.d.ts",
+    "**/*.d.ts",
     "**/*.ts",
     "**/*.tsx",
     ".next/types/**/*.ts",

--- a/types/api.ts
+++ b/types/api.ts
@@ -1,0 +1,92 @@
+/**
+ * API Type Definitions
+ *
+ * Types for API requests, responses, and errors.
+ *
+ * @module types/api
+ */
+
+/**
+ * Standard API error response
+ */
+export interface APIError {
+  code: string;
+  message: string;
+  details?: Record<string, unknown>;
+}
+
+/**
+ * Standard API success response
+ */
+export interface APIResponse<T = unknown> {
+  success: true;
+  data: T;
+}
+
+/**
+ * Standard API error response wrapper
+ */
+export interface APIErrorResponse {
+  success: false;
+  error: APIError;
+}
+
+/**
+ * Combined API response type
+ */
+export type APIResult<T> = APIResponse<T> | APIErrorResponse;
+
+/**
+ * Pagination parameters
+ */
+export interface PaginationParams {
+  page: number;
+  limit: number;
+}
+
+/**
+ * Paginated response
+ */
+export interface PaginatedResponse<T> {
+  items: T[];
+  total: number;
+  page: number;
+  limit: number;
+  hasMore: boolean;
+}
+
+/**
+ * Sort order
+ */
+export type SortOrder = "asc" | "desc";
+
+/**
+ * Generic sort parameters
+ */
+export interface SortParams<T extends string = string> {
+  field: T;
+  order: SortOrder;
+}
+
+/**
+ * File upload progress
+ */
+export interface UploadProgress {
+  loaded: number;
+  total: number;
+  percentage: number;
+}
+
+/**
+ * Rate limit information
+ */
+export interface RateLimitInfo {
+  limit: number;
+  remaining: number;
+  reset: number;
+}
+
+/**
+ * Button/action state for UI feedback
+ */
+export type ButtonState = "idle" | "loading" | "success" | "error";

--- a/types/auth.d.ts
+++ b/types/auth.d.ts
@@ -1,0 +1,48 @@
+/**
+ * NextAuth Type Augmentation
+ *
+ * Extends NextAuth's built-in types to include custom user properties.
+ * This provides type safety for session and JWT token data throughout the app.
+ *
+ * @module types/auth
+ * @see https://next-auth.js.org/getting-started/typescript
+ */
+
+import { type UserRole } from "./database";
+
+declare module "next-auth" {
+  /**
+   * Extends the built-in session user object
+   */
+  interface Session {
+    user: {
+      id: string;
+      name?: string | null;
+      email?: string | null;
+      image?: string | null;
+      role: UserRole;
+      isTrusted: boolean;
+    };
+  }
+
+  /**
+   * Extends the built-in user object
+   */
+  interface User {
+    role?: UserRole;
+    isTrusted?: boolean;
+  }
+}
+
+declare module "next-auth/jwt" {
+  /**
+   * Extends the JWT token object
+   */
+  interface JWT {
+    id?: string;
+    role?: UserRole | string;
+    isTrusted?: boolean;
+  }
+}
+
+export {};

--- a/types/database.ts
+++ b/types/database.ts
@@ -1,0 +1,47 @@
+/**
+ * Database Types
+ *
+ * Centralized exports for Prisma-backed enums/types, plus a few app-level
+ * database-adjacent shapes.
+ *
+ * NOTE: This is a real module (not a .d.ts) so value imports like enums work
+ * at runtime (e.g. in seed scripts).
+ */
+
+export {
+  SocialProvider,
+  SyncStatus,
+  UserRole,
+  UxEffort,
+  UxSeverity,
+  UxStatus,
+} from "@prisma/client";
+
+export type { User } from "@prisma/client";
+
+/**
+ * Application status values used in the tracker.
+ *
+ * Keep as string union to match UI + API payloads.
+ */
+export type ApplicationStatus = "saved" | "applied" | "interviewing" | "offer" | "rejected";
+
+/**
+ * Job application entity shape returned by tRPC (Date objects).
+ */
+export interface ApplicationEntity {
+  id: string;
+  userId: string;
+  company: string;
+  role: string;
+  jobDescription: string;
+  jobUrl: string | null;
+  matchScore: number;
+  analysis: string;
+  coverLetter: string;
+  status: string;
+  appliedAt: Date | null;
+  notes: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,0 +1,27 @@
+/**
+ * Types Barrel Export
+ *
+ * Central export point for all application types.
+ * Provides a single import source for type definitions.
+ *
+ * @example
+ * ```typescript
+ * import type { Application, UserRole, APIResponse } from '@/types';
+ * ```
+ *
+ * @module types
+ */
+
+// Database types
+export * from "./database";
+
+// Domain models
+export * from "./models";
+
+// API types
+export * from "./api";
+
+// Utility types
+export * from "./utils";
+
+// Note: auth.d.ts contains ambient declarations and doesn't need to be re-exported

--- a/types/models/application.ts
+++ b/types/models/application.ts
@@ -1,0 +1,68 @@
+/**
+ * Application Domain Model Types
+ *
+ * Type definitions for job application tracking functionality.
+ * Separates database entities from UI-friendly representations.
+ *
+ * @module types/models/application
+ */
+
+import type { ApplicationStatus } from "../database";
+
+/**
+ * Application data for UI consumption (with string dates)
+ */
+export interface Application {
+  id: string;
+  company: string;
+  role: string;
+  matchScore: number;
+  status: string;
+  appliedAt: string | null;
+  createdAt: string;
+  notes: string | null;
+}
+
+/**
+ * Input for creating a new application
+ */
+export interface CreateApplicationInput {
+  company: string;
+  role: string;
+  jobDescription: string;
+  matchScore: number;
+  analysis: string;
+  coverLetter: string;
+  status: ApplicationStatus;
+}
+
+/**
+ * Input for updating an existing application
+ */
+export interface UpdateApplicationInput {
+  status?: ApplicationStatus;
+  notes?: string;
+  appliedAt?: Date;
+}
+
+/**
+ * Application statistics for dashboard
+ */
+export interface ApplicationStats {
+  total: number;
+  applied: number;
+  interviewing: number;
+  offers: number;
+  avgMatchScore: number;
+}
+
+/**
+ * Filter options for application list
+ */
+export interface ApplicationFilters {
+  status?: ApplicationStatus;
+  search?: string;
+  sortBy?: "recent" | "company" | "matchScore";
+}
+
+export type { ApplicationStatus };

--- a/types/models/index.ts
+++ b/types/models/index.ts
@@ -1,0 +1,36 @@
+/**
+ * Domain Models Barrel Export
+ *
+ * Central export point for all domain model types.
+ *
+ * @module types/models
+ */
+
+// Application models
+export type {
+  Application,
+  CreateApplicationInput,
+  UpdateApplicationInput,
+  ApplicationStats,
+  ApplicationFilters,
+  ApplicationStatus,
+} from "./application";
+
+// UX Research models
+export type {
+  UxPersona,
+  UxJourney,
+  UxJourneyStep,
+  UxPainPoint,
+  UxPrinciple,
+  CreatePersonaInput,
+  CreateJourneyInput,
+  CreatePainPointInput,
+  CreatePrincipleInput,
+  UxSeverity,
+  UxEffort,
+  UxStatus,
+} from "./ux";
+
+// User models
+export type { UserProfile, UpdateProfileInput, CVUploadResult, UserRole } from "./user";

--- a/types/models/user.ts
+++ b/types/models/user.ts
@@ -1,0 +1,55 @@
+/**
+ * User Domain Model Types
+ *
+ * Type definitions for user-related functionality.
+ *
+ * @module types/models/user
+ */
+
+import type { UserRole } from "../database";
+
+/**
+ * User profile data for UI
+ */
+export interface UserProfile {
+  id: string;
+  name: string;
+  email: string;
+  phone?: string | null;
+  location: string;
+  summary: string;
+  experience: string;
+  skills: string[];
+  cvPdfUrl?: string | null;
+  cvLatexUrl?: string | null;
+  cvFilename?: string | null;
+  cvUploadedAt?: string | null;
+  role: UserRole;
+  isTrusted: boolean;
+  isVerified: boolean;
+  image?: string | null;
+}
+
+/**
+ * Input for updating user profile
+ */
+export interface UpdateProfileInput {
+  name?: string;
+  phone?: string;
+  location?: string;
+  summary?: string;
+  experience?: string;
+  skills?: string;
+}
+
+/**
+ * CV upload result
+ */
+export interface CVUploadResult {
+  pdfUrl: string;
+  latexUrl?: string;
+  filename: string;
+  extractedText?: string;
+}
+
+export type { UserRole };

--- a/types/models/ux.ts
+++ b/types/models/ux.ts
@@ -1,0 +1,137 @@
+/**
+ * UX Research Domain Model Types
+ *
+ * Type definitions for UX research platform functionality.
+ *
+ * @module types/models/ux
+ */
+
+import type { UxSeverity, UxEffort, UxStatus } from "../database";
+
+/**
+ * UX Persona
+ */
+export interface UxPersona {
+  id: string;
+  name: string;
+  type: string;
+  description: string;
+  goals: string[];
+  frustrations: string[];
+  behaviors: string[];
+  status: UxStatus;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/**
+ * Journey Step
+ */
+export interface UxJourneyStep {
+  id: string;
+  journeyId: string;
+  orderIndex: number;
+  stage: string;
+  action: string;
+  thinking: string;
+  feeling: string;
+  touchpoint: string;
+  opportunity?: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/**
+ * User Journey
+ */
+export interface UxJourney {
+  id: string;
+  name: string;
+  description: string;
+  personaId?: string | null;
+  status: UxStatus;
+  steps: UxJourneyStep[];
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/**
+ * Pain Point
+ */
+export interface UxPainPoint {
+  id: string;
+  title: string;
+  description: string;
+  category: string;
+  severity: UxSeverity;
+  effort: UxEffort;
+  userQuote?: string | null;
+  solution?: string | null;
+  status: UxStatus;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/**
+ * UX Design Principle
+ */
+export interface UxPrinciple {
+  id: string;
+  name: string;
+  description: string;
+  rationale: string;
+  examples: {
+    do: string[];
+    dont: string[];
+  };
+  priority: number;
+  status: UxStatus;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/**
+ * Input schemas for UX entities
+ */
+export interface CreatePersonaInput {
+  name: string;
+  type: string;
+  description: string;
+  goals: string[];
+  frustrations: string[];
+  behaviors: string[];
+  status?: UxStatus;
+}
+
+export interface CreateJourneyInput {
+  name: string;
+  description: string;
+  personaId?: string;
+  steps: Omit<UxJourneyStep, "id" | "journeyId" | "createdAt" | "updatedAt">[];
+  status?: UxStatus;
+}
+
+export interface CreatePainPointInput {
+  title: string;
+  description: string;
+  category: string;
+  severity: UxSeverity;
+  effort: UxEffort;
+  userQuote?: string;
+  solution?: string;
+  status?: UxStatus;
+}
+
+export interface CreatePrincipleInput {
+  name: string;
+  description: string;
+  rationale: string;
+  examples: {
+    do: string[];
+    dont: string[];
+  };
+  priority?: number;
+  status?: UxStatus;
+}
+
+export type { UxSeverity, UxEffort, UxStatus };

--- a/types/utils.ts
+++ b/types/utils.ts
@@ -1,0 +1,63 @@
+/**
+ * Utility Type Definitions
+ *
+ * Reusable utility types for common patterns.
+ *
+ * @module types/utils
+ */
+
+/**
+ * Makes specific properties of T optional
+ */
+export type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
+
+/**
+ * Makes specific properties of T required
+ */
+export type RequiredBy<T, K extends keyof T> = Omit<T, K> & Required<Pick<T, K>>;
+
+/**
+ * Converts Date fields to string (for JSON serialization)
+ */
+export type WithStringDates<T> = {
+  [K in keyof T]: T[K] extends Date ? string : T[K] extends Date | null ? string | null : T[K];
+};
+
+/**
+ * Converts string fields back to Date
+ */
+export type WithDateObjects<T> = {
+  [K in keyof T]: T[K] extends string ? Date : T[K] extends string | null ? Date | null : T[K];
+};
+
+/**
+ * Extracts the element type from an array
+ */
+export type ArrayElement<T> = T extends (infer U)[] ? U : never;
+
+/**
+ * Makes all properties deeply optional
+ */
+export type DeepPartial<T> = {
+  [K in keyof T]?: T[K] extends object ? DeepPartial<T[K]> : T[K];
+};
+
+/**
+ * Extracts keys of T that are of type U
+ */
+export type KeysOfType<T, U> = { [K in keyof T]: T[K] extends U ? K : never }[keyof T];
+
+/**
+ * Promise unwrapper - extracts the resolved type
+ */
+export type Awaited<T> = T extends Promise<infer U> ? U : T;
+
+/**
+ * Nullable version of T
+ */
+export type Nullable<T> = T | null;
+
+/**
+ * Non-nullable version of T (removes null and undefined)
+ */
+export type NonNullable<T> = Exclude<T, null | undefined>;


### PR DESCRIPTION
Brings in the “TypeScript architecture” idea from Claude’s branch, adapted to work cleanly with Prisma + strict TS.

Highlights
- Adds `types/` module with barrel exports at `@/types`
- Adds `types/auth.d.ts` NextAuth type augmentation and updates `tsconfig.json` to include `**/*.d.ts`
- Uses a real runtime module for database enums/types via `types/database.ts` (re-exports Prisma enums) so value imports work (e.g. seed scripts)
- Updates:
  - `lib/auth.ts` (removes inline module augmentation)
  - `lib/hooks/useApplications.ts` (uses centralized types)
  - `lib/trpc/routers/ux.ts` and `prisma/seed-ux.ts` (imports from `@/types`)
  - `__tests__/integration/user-router.test.ts`

Validation
- `npm run validate` locally passed (lint + type-check + format:check + tests)