### PR TITLE
fix(auth): stop prod login redirect loop by reading secure NextAuth cookie

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -144,9 +144,15 @@ export default async function proxy(req: NextRequest): Promise<NextResponse> {
     return NextResponse.redirect(new URL("/login?error=configuration", req.url));
   }
 
+  // In production/preview on Vercel, NextAuth uses secure cookie names (e.g. `__Secure-...`).
+  // The edge runtime can mis-detect this depending on deployment URL/proto.
+  // Force secure cookie parsing in prod to avoid redirect loops to /login.
+  const secureCookie = process.env.NODE_ENV === "production";
+
   const token = await getToken({
     req,
     secret: authSecret,
+    secureCookie,
   });
 
   const isAuthenticated = !!token;


### PR DESCRIPTION
## What
Fixes a production-only auth redirect loop where users are sent back to `/login` when navigating to protected pages (e.g. `/profile?_rsc=...`).

## Why
In production on Vercel, NextAuth uses secure cookie names (e.g. `__Secure-...`). The proxy’s `getToken()` call can mis-detect cookie mode depending on URL/proto/env and fail to read the session cookie, making the proxy think the user is unauthenticated.

## Change
- Force secure-cookie parsing in production by passing `secureCookie: process.env.NODE_ENV === "production"` to `getToken()`.

## Notes
- Please also confirm Vercel env vars are correct:
  - `AUTH_SECRET` set for Production and stable
  - `NEXTAUTH_URL` set to the exact HTTPS production domain

## Validation
- `npm run validate`