### PR TITLE
docs: consolidate and refresh deployment/auth guidance

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -106,6 +106,9 @@ Every deployment goes through 4 validation layers:
 **Required (Production):**
 
 - `DATABASE_URL` - PostgreSQL connection string
+- `AUTH_SECRET` - NextAuth JWT secret (required for route protection)
+- `NEXTAUTH_URL` - Production URL (recommended; helps cookie/redirect correctness)
+- `AUTH_GITHUB_ID` / `AUTH_GITHUB_SECRET` - OAuth sign-in (or Google/LinkedIn)
 - `AI_PROVIDER` - `gemini`, `openai`, or `claude`
 - `GEMINI_API_KEY` - Your Gemini API key
 
@@ -113,6 +116,10 @@ Every deployment goes through 4 validation layers:
 
 - `OPENAI_API_KEY` - If using OpenAI
 - `ANTHROPIC_API_KEY` - If using Claude
+- `AUTH_GOOGLE_ID` / `AUTH_GOOGLE_SECRET` - Google sign-in
+- `AUTH_LINKEDIN_ID` / `AUTH_LINKEDIN_SECRET` - LinkedIn sign-in
+- `SOCIAL_ENCRYPTION_KEY` - Required if using social integrations (GitHub/LinkedIn sync)
+- `OWNER_EMAIL` - Required for OWNER role assignment (admin features)
 
 **View current variables:**
 
@@ -130,7 +137,9 @@ vercel env pull .env.production
 
 ## Database Migrations
 
-Migrations run automatically during Vercel build (configured in `build:production` script).
+Migrations are **not** run automatically during Vercel builds.
+
+`build:production` currently runs `prisma generate && next build` (no `prisma migrate deploy`).
 
 **Manual migration:**
 

--- a/OAUTH_VERCEL_SETUP.md
+++ b/OAUTH_VERCEL_SETUP.md
@@ -11,12 +11,16 @@ This guide walks through configuring GitHub, Google, and LinkedIn OAuth for your
 3. Update "Authorization callback URL":
    - **From:** `http://localhost:3000/api/auth/callback/github`
    - **To:** `https://job-hunting-assistant.vercel.app/api/auth/callback/github`
-4. **Keep localhost for local dev** - you can add multiple URLs, separated by commas or newlines
 
-After updating, your callback URLs should be:
+4. **Important (GitHub limitation):** GitHub OAuth Apps only support **one** callback URL per app.
+
+   Recommended options:
+   - **Best:** Create **separate OAuth Apps** for local dev and production.
+   - **OK for quick testing:** Temporarily switch the callback URL when testing prod, then switch it back for local dev.
+
+After updating, your callback URL should be:
 
 ```
-http://localhost:3000/api/auth/callback/github
 https://job-hunting-assistant.vercel.app/api/auth/callback/github
 ```
 
@@ -100,6 +104,8 @@ Make sure these are set in Vercel (same values as your `.env`):
 - `DATABASE_URL` ✓
 - `NEXTAUTH_URL` (new)
 
+Tip: Keep `AUTH_SECRET` stable across deploys. If it changes, existing sessions become invalid.
+
 ---
 
 ## Testing
@@ -123,6 +129,16 @@ Make sure these are set in Vercel (same values as your `.env`):
 - ✓ Set `NEXTAUTH_URL` in Vercel environment
 - ✓ Redeploy after changing environment variables
 - ✓ Wait 1-2 minutes for Vercel to fully deploy
+
+### Stuck on /login after successful sign-in (production)
+
+If `/api/auth/session` returns `200` but navigating to `/dashboard`/`/profile` redirects back to `/login`, the route-protection proxy may not be reading the secure session cookie.
+
+Checklist:
+
+- ✓ Confirm `AUTH_SECRET` and `NEXTAUTH_URL` are set correctly in Vercel (Production)
+- ✓ Confirm you are using the correct HTTPS URL in `NEXTAUTH_URL`
+- ✓ Deploy the latest `proxy.ts` changes (the proxy forces secure-cookie parsing in production)
 
 ### Local dev broken after changes
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Open http://localhost:3000
 ## 🚀 Tech Stack
 
 - **Frontend:** Next.js 16, TypeScript, TailwindCSS, Shadcn/ui
-- **Backend:** Next.js API Routes, Prisma ORM, PostgreSQL (Neon)
+- **Backend:** App Router route handlers + tRPC, Prisma ORM, PostgreSQL (Neon)
 - **AI:** Multi-provider support
   - Google Gemini 2.0 Flash (FREE - 1,500 requests/day) ⭐ Recommended
   - OpenAI GPT-4o-mini (Paid - ~$0.0005/analysis)
@@ -65,6 +65,7 @@ Open http://localhost:3000
 
 - **[SETUP.md](./SETUP.md)** - Quick start guide and local setup
 - **[DEPLOYMENT.md](./docs/DEPLOYMENT.md)** - Production deployment to Vercel 🚀
+- **[Docs Index](./docs/README.md)** - Central index (less doc sprawl)
 - **[STRICT_RULES.md](./docs/STRICT_RULES.md)** - Code quality and validation rules
 - **[Roadmap](./docs/ROADMAP.md)** - What’s next (v1.2+ milestones)
 - **[Implementation Plan (Archived)](./docs/archive/IMPLEMENTATION_PLAN.md)** - MVP build notes (historical)
@@ -81,6 +82,8 @@ This app is production-ready with:
 - ✅ **Pre-Deployment Validation** - Automated checks before every deploy
 - ✅ **Multi-Layer Quality Gates** - Pre-commit, pre-push, and CI checks
 - ✅ **Security Headers** - XSS protection, frame-deny, CSP
+
+Note: Route protection uses the Next.js proxy pattern (`proxy.ts`) (middleware is not used).
 
 **Deploy now:** See [DEPLOYMENT.md](./docs/DEPLOYMENT.md) for step-by-step guide.
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -88,6 +88,19 @@ vercel env add GEMINI_API_KEY production
 # Optional: Add other AI providers
 vercel env add OPENAI_API_KEY production
 vercel env add ANTHROPIC_API_KEY production
+
+# Authentication (required)
+vercel env add AUTH_SECRET production
+vercel env add NEXTAUTH_URL production
+
+# OAuth providers (at least one required for sign-in)
+vercel env add AUTH_GITHUB_ID production
+vercel env add AUTH_GITHUB_SECRET production
+# Optional:
+vercel env add AUTH_GOOGLE_ID production
+vercel env add AUTH_GOOGLE_SECRET production
+vercel env add AUTH_LINKEDIN_ID production
+vercel env add AUTH_LINKEDIN_SECRET production
 ```
 
 **Option B: Via Vercel Dashboard**
@@ -164,8 +177,8 @@ After first deployment, run migrations:
 vercel env pull .env.production  # Download production env vars
 DATABASE_URL="your-production-url" npx prisma migrate deploy
 
-# Option B: Migrations run automatically during build
-# (Already configured in build:production script)
+# Note: Migrations are not run automatically during Vercel builds.
+# `build:production` currently runs `prisma generate && next build`.
 ```
 
 ---
@@ -208,7 +221,7 @@ DATABASE_URL="your-production-url" npx prisma migrate deploy
 ## 🛠️ Production Scripts Reference
 
 ```bash
-# Build for production (with migrations)
+# Build for production
 npm run build:production
 
 # Database commands

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,40 +1,30 @@
-# Learning Docs
+# Docs Index
 
-Quick-read guides (3-5 min each) documenting what I learned building this.
+This folder contains both **project documentation** (setup/deploy/security) and **learning notes** captured while building.
 
----
+## Start Here
 
-## 📚 Guides
+- Local setup: ../SETUP.md
+- Production deploy: ./DEPLOYMENT.md (quick reference also available at ../DEPLOY.md)
+- OAuth/Vercel configuration: ../OAUTH_VERCEL_SETUP.md
 
-**AI Integration:**
+## Project Docs
 
-- [ai-debugging.md](./ai-debugging.md) - Gemini API, defensive coding, multi-provider architecture
+- Security audit: ./SECURITY_AUDIT.md
+- Roadmap: ./ROADMAP.md
+- PRD: ./PRD.md
+- Testing: ./TESTING_SETUP.md
+- Strict rules / quality gates: ./STRICT_RULES.md
 
-**Next.js Patterns:**
+## Learning Docs (3–5 min reads)
 
-- [nextjs-patterns.md](./nextjs-patterns.md) - Server vs Client Components, API routes, file structure
+- AI integration: ./ai-debugging.md
+- Next.js patterns: ./nextjs-patterns.md
+- Database decisions: ./database-decisions.md
+- Code quality notes: ./code-quality.md
 
-**Database:**
+## Archive
 
-- [database-decisions.md](./database-decisions.md) - Prisma + PostgreSQL decisions (includes historical SQLite → Postgres notes)
+Historical documents live in ./archive/.
 
-**Code Quality:**
-
-- [code-quality.md](./code-quality.md) - ESLint cleanup, technical debt decisions, .env patterns
-
----
-
-## 🎯 Philosophy
-
-Each doc is:
-
-- **Focused** - One topic, one file
-- **Quick** - 3-5 min read max
-- **Practical** - Real problems, real solutions
-- **Honest** - Includes mistakes and trade-offs
-
-No fluff, no AI-generated filler. Just what I actually learned.
-
----
-
-**Last updated:** Dec 12, 2025
+**Last updated:** Dec 14, 2025


### PR DESCRIPTION
Updates docs to match the real app behavior and architecture:

- Clarifies that route protection uses the proxy (not deprecated middleware)
- Fixes Vercel/OAuth guidance (single GitHub callback URL, required env vars)
- Corrects deployment notes (migrations are not run automatically during build)
- Consolidates docs entrypoint via docs index

Validation: `npm run validate` (passes)