### PR TITLE
fix(auth): remove Google and LinkedIn OAuth providers

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -45,43 +45,6 @@ function GitHubIcon(): JSX.Element {
 }
 
 /**
- * Google Icon
- */
-function GoogleIcon(): JSX.Element {
-  return (
-    <svg className="h-5 w-5" viewBox="0 0 24 24">
-      <path
-        fill="#4285F4"
-        d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
-      />
-      <path
-        fill="#34A853"
-        d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
-      />
-      <path
-        fill="#FBBC05"
-        d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
-      />
-      <path
-        fill="#EA4335"
-        d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
-      />
-    </svg>
-  );
-}
-
-/**
- * LinkedIn Icon
- */
-function LinkedInIcon(): JSX.Element {
-  return (
-    <svg className="h-5 w-5" viewBox="0 0 24 24" fill="#0A66C2">
-      <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
-    </svg>
-  );
-}
-
-/**
  * Error Banner
  */
 function ErrorBanner({ error }: { error: string | null }): JSX.Element | null {
@@ -154,32 +117,10 @@ function LoginContent(): JSX.Element {
 
           <div className="space-y-3">
             <OAuthButton
-              label="Continue with LinkedIn"
-              icon={<LinkedInIcon />}
-              loading={loadingProvider === "linkedin"}
-              onClick={() => handleSignIn("linkedin")}
-            />
-
-            <div className="relative my-4">
-              <div className="absolute inset-0 flex items-center">
-                <div className="w-full border-t border-slate-200" />
-              </div>
-              <div className="relative flex justify-center text-sm">
-                <span className="bg-white px-2 text-slate-500">or</span>
-              </div>
-            </div>
-
-            <OAuthButton
               label="Continue with GitHub"
               icon={<GitHubIcon />}
               loading={loadingProvider === "github"}
               onClick={() => handleSignIn("github")}
-            />
-            <OAuthButton
-              label="Continue with Google"
-              icon={<GoogleIcon />}
-              loading={loadingProvider === "google"}
-              onClick={() => handleSignIn("google")}
             />
           </div>
 

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -13,19 +13,11 @@ import { type UserRole } from "@/types";
 import { PrismaAdapter } from "@auth/prisma-adapter";
 import NextAuth from "next-auth";
 import GitHub from "next-auth/providers/github";
-import Google from "next-auth/providers/google";
-import LinkedIn from "next-auth/providers/linkedin";
 
 export const { handlers, signIn, signOut, auth } = NextAuth({
   adapter: PrismaAdapter(prisma),
 
   providers: [
-    LinkedIn({
-      clientId: process.env.AUTH_LINKEDIN_ID!,
-      clientSecret: process.env.AUTH_LINKEDIN_SECRET!,
-      // SECURITY: Removed allowDangerousEmailAccountLinking to prevent account takeover
-      // Users must link accounts manually through settings if they want multiple providers
-    }),
     GitHub({
       clientId: process.env.AUTH_GITHUB_ID!,
       clientSecret: process.env.AUTH_GITHUB_SECRET!,
@@ -35,12 +27,6 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
           scope: "read:user user:email",
         },
       },
-      // SECURITY: Removed allowDangerousEmailAccountLinking to prevent account takeover
-    }),
-    Google({
-      clientId: process.env.AUTH_GOOGLE_ID!,
-      clientSecret: process.env.AUTH_GOOGLE_SECRET!,
-      // SECURITY: Removed allowDangerousEmailAccountLinking to prevent account takeover
     }),
   ],
 


### PR DESCRIPTION
## Summary
Remove Google and LinkedIn OAuth providers from authentication config. Keep GitHub OAuth only.

## Changes
- Remove LinkedIn and Google providers from `lib/auth.ts`
- Remove LinkedIn and Google buttons from login page
- Keep GitHub OAuth fully functional

## Why
Simplifies authentication to GitHub OAuth (for developers). Email/password will be added in a follow-up PR (#99).

Closes #100