### PR TITLE
fix(nav): hide Admin link from navigation

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -80,12 +80,6 @@ export default function RootLayout({
                         >
                           Settings
                         </Link>
-                        <Link
-                          href="/admin/flags"
-                          className="text-slate-400 hover:text-slate-600 transition-colors text-sm"
-                        >
-                          Admin
-                        </Link>
                       </div>
                     </div>
                     {/* User Menu */}

--- a/components/mobile-menu.tsx
+++ b/components/mobile-menu.tsx
@@ -32,7 +32,6 @@ export function MobileMenu({ className }: MobileMenuProps): JSX.Element {
     { href: "/analyze", label: "Analyze Job" },
     { href: "/tracker", label: "Tracker" },
     { href: "/settings", label: "Settings" },
-    { href: "/admin/flags", label: "Admin", secondary: true },
   ];
 
   return (
@@ -127,9 +126,7 @@ export function MobileMenu({ className }: MobileMenuProps): JSX.Element {
                   "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fjord-500 focus-visible:ring-offset-2",
                   isActive
                     ? "bg-fjord-50 text-fjord-700 border-l-4 border-fjord-600"
-                    : link.secondary
-                      ? "text-slate-400 hover:text-slate-600 hover:bg-nordic-neutral-50"
-                      : "text-nordic-neutral-700 hover:bg-nordic-neutral-50 hover:text-nordic-neutral-900"
+                    : "text-nordic-neutral-700 hover:bg-nordic-neutral-50 hover:text-nordic-neutral-900"
                 )}
                 onClick={() => setIsOpen(false)}
               >


### PR DESCRIPTION
## Summary
Remove Admin link from desktop and mobile navigation for cleaner portfolio UI.

## Changes
- Remove Admin link from desktop nav in `app/layout.tsx`
- Remove Admin link from mobile nav in `components/mobile-menu.tsx`
- Remove `secondary` styling logic (was only used for Admin)

## Notes
- Admin pages (`/admin/flags`, `/admin/ux-planner`) remain accessible via direct URL for authorized users
- AdminGuard component continues to protect admin routes

## Why
Admin tools are internal utilities, not portfolio showcases. Hiding from nav provides a cleaner UX for demo purposes.

Closes #102