### PR TITLE
docs: Simplify documentation for portfolio focus

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,95 +1,129 @@
-# Job Hunt AI
+# Job Hunting Assistant
 
-Job Hunt AI eliminates the friction from job hunting through AI-powered CV analysis, cover letter generation, and intelligent application management.
+AI-powered job hunting tool that analyzes job descriptions, generates tailored cover letters, and helps you track applications — all in one place.
 
-**Live Demo:** [job-hunting-assistant.vercel.app](https://job-hunting-assistant.vercel.app)
-
----
-
-## 🎯 Features (v1.1)
-
-### Core Features
-
-- **AI-Powered Job Analysis** - Analyze job descriptions against your CV with match scores (0-100%)
-- **Cover Letter Generation** - Automatically generate tailored cover letters (max 250 words)
-- **Application Tracking** - Track all job applications with status, dates, and notes
-- **Master CV System** - Maintain one source of truth for your professional profile
-- **CV Upload** - Import PDF/DOCX files with AI-powered data extraction
-- **CV LaTeX Editor** - Edit and compile professional CV templates
-
-### Authentication & Integrations (v1.1)
-
-- **OAuth Sign-In** - GitHub, Google, LinkedIn authentication
-- **GitHub Integration** - Import repos, languages, contributions
-- **LinkedIn Integration** - Profile sync (API limited)
-- **Mobile Navigation** - Responsive hamburger menu for mobile devices
-
-### Free AI Option
-
-- Use Google Gemini (1,500 free analyses/day) or paid options (OpenAI, Claude)
+**🚀 Live Demo:** [job-hunting-assistant.vercel.app](https://job-hunting-assistant.vercel.app)
 
 ---
 
-## 🚀 Quick Start
+## ✨ Features
 
-See **[FREE-AI-SETUP.md](./FREE-AI-SETUP.md)** for using the free Google Gemini option (recommended).
+### LaTeX CV Editor (Main Showcase)
 
-Or see **[SETUP.md](./SETUP.md)** for complete setup instructions.
+- Upload PDF/DOCX and AI extracts content to LaTeX
+- Multiple professional templates with instant switching
+- Live PDF preview and compilation
+- ATS compliance checking
 
-**TL;DR (Free Setup):**
+### AI Job Analysis
+
+- Paste any job description
+- Get match score (0-100%) based on your CV
+- See skill gaps and recommendations
+- Identify top requirements
+
+### Cover Letter Generation
+
+- One-click AI-generated cover letters
+- Tailored to specific job + your experience
+- Professional tone, concise format
+
+### Application Tracker
+
+- Track all applications in one place
+- Status workflow: Saved → Applied → Interview → Offer
+- Notes, dates, and company details
+
+---
+
+## 🛠 Tech Stack
+
+| Layer          | Technology                                       |
+| -------------- | ------------------------------------------------ |
+| **Frontend**   | Next.js 16 (App Router), React 19, TypeScript    |
+| **Styling**    | TailwindCSS 4, Shadcn/ui components              |
+| **Backend**    | tRPC v11 with React Query                        |
+| **Database**   | PostgreSQL (Neon) with Prisma ORM                |
+| **Auth**       | NextAuth.js v5 with GitHub OAuth                 |
+| **AI**         | Google Gemini 2.5 Flash (free tier) + OpenRouter |
+| **Deployment** | Vercel with CI/CD                                |
+
+---
+
+## 💡 What This Demonstrates
+
+| Skill                     | Implementation                                               |
+| ------------------------- | ------------------------------------------------------------ |
+| **Full-Stack TypeScript** | End-to-end type safety with Next.js + tRPC + Prisma          |
+| **AI Integration**        | Multi-model support, streaming responses, prompt engineering |
+| **Modern React**          | Server Components, Suspense, custom hooks                    |
+| **API Design**            | Type-safe tRPC procedures with Zod validation                |
+| **Database Design**       | PostgreSQL schema with Prisma, connection pooling            |
+| **Authentication**        | OAuth flow with NextAuth.js v5, JWT sessions                 |
+| **Code Quality**          | ESLint, Prettier, Husky hooks, automated testing             |
+| **DevOps**                | Vercel deployment, pre-commit validation, CI checks          |
+
+---
+
+## 📸 Screenshots
+
+<!-- TODO: Add screenshots -->
+
+_Coming soon_
+
+---
+
+## 🧪 Running Locally
+
+### Prerequisites
+
+- Node.js 18+
+- PostgreSQL database (or use [Neon](https://neon.tech) free tier)
+- Gemini API key (free from [AI Studio](https://aistudio.google.com/app/apikey))
+
+### Setup
 
 ```bash
-# Get free Gemini API key from: https://aistudio.google.com/app/apikey
+# Clone and install
+git clone https://github.com/RafaelMurad/job-hunting-assistant.git
+cd job-hunting-assistant
 npm install
-npx prisma migrate dev --name init
-# Add GEMINI_API_KEY to .env.local
+
+# Configure environment
+cp .env.example .env.local
+# Edit .env.local with your DATABASE_URL and GEMINI_API_KEY
+
+# Setup database
+npx prisma generate
+npx prisma db push
+
+# Run development server
 npm run dev
 ```
 
-Open http://localhost:3000
+Open [http://localhost:3000](http://localhost:3000)
 
 ---
 
-## 🚀 Tech Stack
+## 📁 Project Structure
 
-- **Frontend:** Next.js 16, TypeScript, TailwindCSS, Shadcn/ui
-- **Backend:** App Router route handlers + tRPC, Prisma ORM, PostgreSQL (Neon)
-- **AI:** Multi-provider support
-  - Google Gemini 2.0 Flash (FREE - 1,500 requests/day) ⭐ Recommended
-  - OpenAI GPT-4o-mini (Paid - ~$0.0005/analysis)
-  - Claude Sonnet 4.5 (Paid - ~$0.002/analysis)
+```
+app/                    # Next.js App Router pages
+├── dashboard/          # Stats overview
+├── profile/            # CV upload and profile management
+├── analyze/            # Job analysis + cover letter generation
+├── cv/                 # LaTeX CV editor
+└── tracker/            # Application tracking
 
----
+lib/
+├── ai/                 # AI providers and prompts
+├── trpc/               # tRPC routers and procedures
+├── hooks/              # Custom React hooks
+└── validations/        # Zod schemas
 
-## 📖 Documentation
-
-- **[SETUP.md](./SETUP.md)** - Quick start guide and local setup
-- **[DEPLOYMENT.md](./docs/DEPLOYMENT.md)** - Production deployment to Vercel 🚀
-- **[Docs Index](./docs/README.md)** - Central index (less doc sprawl)
-- **[STRICT_RULES.md](./docs/STRICT_RULES.md)** - Code quality and validation rules
-- **[Roadmap](./docs/ROADMAP.md)** - What’s next (v1.2+ milestones)
-- **[Implementation Plan (Archived)](./docs/archive/IMPLEMENTATION_PLAN.md)** - MVP build notes (historical)
-- **[PRD](./docs/PRD.md)** - Product Requirements Document
-
----
-
-## 🌐 Production Deployment
-
-This app is production-ready with:
-
-- ✅ **Vercel Deployment** - One-click deploy with automatic CI/CD
-- ✅ **PostgreSQL Database** - Production-ready with connection pooling
-- ✅ **Pre-Deployment Validation** - Automated checks before every deploy
-- ✅ **Multi-Layer Quality Gates** - Pre-commit, pre-push, and CI checks
-- ✅ **Security Headers** - XSS protection, frame-deny, CSP
-
-Note: Route protection uses the Next.js proxy pattern (`proxy.ts`) (middleware is not used).
-
-**Deploy now:** See [DEPLOYMENT.md](./docs/DEPLOYMENT.md) for step-by-step guide.
-
-```bash
-# Deploy to Vercel (with validation)
-npm run vercel:deploy:production
+components/
+├── ui/                 # Shadcn/ui components
+└── ...                 # Feature components
 ```
 
 ---
@@ -98,10 +132,7 @@ npm run vercel:deploy:production
 
 **Rafael Murad**
 
-Senior Frontend Engineer with expertise in React, TypeScript, Next.js, and Redux. Previously at Just Eat, delivering features to millions of users across 15+ European markets.
+Senior Frontend Engineer • React, TypeScript, Next.js
 
 - GitHub: [@RafaelMurad](https://github.com/RafaelMurad)
-
----
-
-**Built with ❤️ using Claude Code**
+- LinkedIn: [linkedin.com/in/rafaelmurad](https://linkedin.com/in/rafaelmurad)

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -2,9 +2,8 @@
 
 ## Job Hunting Assistant
 
-**Product Version:** v1.1 (Stable)  
-**Document Revision:** 1.5  
-**Last Updated:** December 12, 2025  
+**Product Version:** v1.2 (Portfolio)  
+**Last Updated:** January 4, 2026  
 **Author:** Rafael Murad
 
 ---
@@ -15,30 +14,27 @@
 
 Job hunting is fragmented, tedious, and hard to track:
 
-- **Boilerplate job descriptions** — Most don't accurately describe the role or get tech skills right
 - **CV tailoring** — Updating your CV for each application is time-consuming
-- **Cover letter writing** — Creating personalized letters is painful (especially if writing isn't your strength)
-- **Application tracking** — Remembering what you applied for is difficult; LinkedIn's tools aren't helpful
-- **Context switching** — Using multiple tools (LinkedIn, Google Docs, spreadsheets) fragments the experience
+- **Cover letter writing** — Creating personalized letters is painful
+- **Application tracking** — Remembering what you applied for is difficult
+- **Context switching** — Using multiple tools fragments the experience
 
 ### The Solution
 
-**Job Hunting Assistant** automates and enhances the job hunting experience by centralizing everything in one place:
+**Job Hunting Assistant** centralizes the job hunting experience:
 
-- Analyze job descriptions and get match scores based on your actual experience
+- Analyze job descriptions and get match scores based on your CV
 - Generate tailored cover letters with one click
-- Import your CV and let AI extract your information
+- Edit CVs with a professional LaTeX editor
 - Track all applications with status, notes, and history
 
 ### Vision Statement
 
-> "An AI-powered job hunting platform that connects to your professional footprint (GitHub, LinkedIn, CV) to deeply understand your experience and help you apply smarter, not harder."
+> "An AI-powered job hunting tool that helps you apply smarter, not harder."
 
 ---
 
 ## 2. Target User
-
-### Primary User (v1.0)
 
 **Job seekers** who:
 
@@ -47,189 +43,46 @@ Job hunting is fragmented, tedious, and hard to track:
 - Want to understand how well they match a job before applying
 - Value having their job search organized in one place
 
-### Initial User
+---
 
-- Rafael Murad (developer and sole user during MVP development)
+## 3. Core Features
 
-### Future Users
-
-- Developers seeking tech roles (leverage GitHub integration)
-- Professionals with LinkedIn presence (leverage LinkedIn integration)
-- Career changers needing help positioning their experience
+| Feature                     | Description                            | Status  |
+| --------------------------- | -------------------------------------- | ------- |
+| **CV Import**               | Upload PDF/DOCX → AI extracts to LaTeX | ✅ Done |
+| **LaTeX CV Editor**         | Edit CVs with professional templates   | ✅ Done |
+| **Job Analysis**            | Paste job → Get match score + insights | ✅ Done |
+| **Cover Letter Generation** | AI-generated tailored letters          | ✅ Done |
+| **Application Tracker**     | Track status, dates, notes             | ✅ Done |
+| **Dashboard**               | Overview stats and quick actions       | ✅ Done |
 
 ---
 
-## 3. v1.0 Feature Scope
+## 4. Technical Architecture
 
-### Core Features
+### Stack
 
-| Feature                     | Description                                                 | Priority |
-| --------------------------- | ----------------------------------------------------------- | -------- |
-| **CV Import**               | Upload PDF/DOCX → AI extracts info → Populates profile      | P0       |
-| **User Profile**            | Store and edit CV information (experience, skills, summary) | P0       |
-| **Job Analysis**            | Paste job description → Get match score + insights          | P0       |
-| **Cover Letter Generation** | Generate tailored cover letter based on profile + job       | P0       |
-| **Application Tracker**     | Track applications: company, role, status, date, notes      | P0       |
-| **Production Deployment**   | Deployed to Vercel with PostgreSQL database                 | P0       |
+| Layer         | Technology                                |
+| ------------- | ----------------------------------------- |
+| **Framework** | Next.js 16 (App Router)                   |
+| **Language**  | TypeScript                                |
+| **Styling**   | TailwindCSS 4 + Shadcn/ui                 |
+| **Database**  | PostgreSQL (Neon)                         |
+| **ORM**       | Prisma                                    |
+| **AI**        | Gemini 2.5 Flash + OpenRouter (free tier) |
+| **Auth**      | NextAuth.js v5 (GitHub OAuth)             |
+| **Hosting**   | Vercel                                    |
 
-### Completed Features
+### Data Models
 
-| Feature                          | Status  | Sprint   |
-| -------------------------------- | ------- | -------- |
-| Nordic Design System             | ✅ Done | Sprint 1 |
-| Prisma ORM Setup                 | ✅ Done | Sprint 1 |
-| Component Library (Shadcn/ui)    | ✅ Done | Sprint 1 |
-| Production PostgreSQL (Neon)     | ✅ Done | Sprint 2 |
-| Deploy to Vercel                 | ✅ Done | Sprint 2 |
-| CI/CD Pipeline (GitHub Actions)  | ✅ Done | Sprint 2 |
-| User Profile API (CRUD)          | ✅ Done | Sprint 3 |
-| CV Upload with AI Extraction     | ✅ Done | Sprint 3 |
-| Profile Page UI                  | ✅ Done | Sprint 3 |
-| Job Analysis API                 | ✅ Done | Sprint 4 |
-| Match Score Algorithm            | ✅ Done | Sprint 4 |
-| Analysis Results UI              | ✅ Done | Sprint 4 |
-| Cover Letter Generation API      | ✅ Done | Sprint 5 |
-| Cover Letter UI                  | ✅ Done | Sprint 5 |
-| Application Tracker API          | ✅ Done | Sprint 6 |
-| Tracker List UI                  | ✅ Done | Sprint 6 |
-| Dashboard Overview               | ✅ Done | Sprint 6 |
-| **v1.0 MVP Launch**              | 🎉 Done | Dec 2024 |
-| CV LaTeX Editor                  | ✅ Done | Sprint 7 |
-| CV Template System (3 templates) | ✅ Done | Sprint 7 |
-| Multi-Model AI Selection         | ✅ Done | Sprint 7 |
-| Instant Template Switching       | ✅ Done | Sprint 7 |
+**Canonical source:** `prisma/schema.prisma`
 
-### NOT in v1.0 (Planned for v1.1+)
-
-| Feature                  | Reason                                                       | Target   | Status  |
-| ------------------------ | ------------------------------------------------------------ | -------- | ------- |
-| **GitHub Integration**   | Core differentiator — adds real project context              | **v1.1** | ✅ Done |
-| **LinkedIn Integration** | Core differentiator — automates tracking, detects mismatches | **v1.1** | ✅ Done |
-| **Multi-user Auth**      | Enable multiple users with OAuth                             | **v1.1** | ✅ Done |
-| PDF CV Export            | Can use browser print initially                              | v1.2     | Planned |
-| Interview AI Helper      | Separate product vertical                                    | v2.0     | Planned |
+- `User` — Profile + CV content + auth metadata
+- `Application` — Tracker data + analysis + cover letter
 
 ---
 
-## 4. Feature Roadmap
-
-### Sprint Schedule (1-week sprints)
-
-```
-Sprint 1: Foundation ✅ (Complete)
-├── ✅ Nordic Design System
-├── ✅ Prisma Schema (User, Application models)
-└── ✅ Component Library Setup
-
-Sprint 2: Infrastructure ✅ (Complete)
-├── ✅ Production PostgreSQL (Neon)
-├── ✅ Deploy to Vercel
-├── ✅ Environment Configuration
-└── ✅ CI/CD Pipeline (GitHub Actions)
-
-Sprint 3: Profile & CV Import ✅ (Complete)
-├── ✅ User Profile API (CRUD)
-├── ✅ CV Upload Endpoint
-├── ✅ PDF/DOCX Text Extraction (Gemini Vision)
-├── ✅ AI Profile Data Extraction
-└── ✅ Profile Page UI (functional)
-
-Sprint 4: Job Analysis ✅ (Complete)
-├── ✅ Job Analysis API
-├── ✅ Match Score Algorithm
-├── ✅ Skills Gap Analysis
-├── ✅ Analysis Results UI
-└── ✅ Job Description Parser
-
-Sprint 5: Cover Letters ✅ (Complete)
-├── ✅ Cover Letter Generation API
-├── ✅ Prompt Engineering for Quality
-├── ✅ Cover Letter UI
-├── ✅ Edit & Regenerate Flow
-└── ✅ Copy/Export Options
-
-Sprint 6: Tracker + Launch ✅ (Complete)
-├── ✅ Application Tracker API
-├── ✅ Tracker List UI
-├── ✅ Status Management
-├── ✅ Dashboard Overview
-├── ✅ Final Polish
-└── 🎉 v1.0 Launch! (December 2024)
-
-Sprint 7: CV Editor & Templates ✅ (Complete)
-├── ✅ CV LaTeX Editor with Live Preview
-├── ✅ 3 Professional Templates (Tech Minimalist, Modern Clean, Contemporary Professional)
-├── ✅ Multi-Model AI Selection (Gemini, OpenRouter free models, GPT-4o, Claude)
-├── ✅ JSON Content Extraction for Template Flexibility
-├── ✅ Instant Template Switching (no re-upload needed)
-├── ✅ PDF/DOCX/LaTeX File Support
-└── ✅ LaTeX Compilation to PDF
-
-Sprint 8: UX Research & Planning ✅ (Complete)
-├── ✅ UX Documentation (/docs/ux/)
-│   ├── User Journeys (5 flows mapped)
-│   ├── Pain Points Analysis (9 issues prioritized)
-│   ├── Information Architecture
-│   └── Design Principles
-├── ✅ Interactive UX Planner (/admin/ux-planner)
-│   ├── Journey Visualization
-│   ├── Persona Exploration
-│   └── Priority Matrix
-├── ✅ Admin Navigation
-└── ✅ Cloud Infrastructure Roadmap (PRD)
-
-Sprint 9: Authentication & Social Integrations ✅ (Complete)
-├── ✅ NextAuth.js v5 with JWT Strategy
-│   ├── GitHub OAuth Provider
-│   ├── Google OAuth Provider
-│   └── LinkedIn OAuth Provider
-├── ✅ User Role System (USER, ADMIN, OWNER)
-├── ✅ Route Protection Middleware (edge-compatible)
-├── ✅ Social Integration System
-│   ├── GitHub: Repos, Languages, Contributions
-│   ├── LinkedIn: Profile Sync (API limited)
-│   └── Token Encryption (AES-256-GCM)
-├── ✅ Settings Page with Integration Management
-├── ✅ Feature Flags for Integrations
-├── ✅ Admin Guard Component
-└── ✅ Login Page with OAuth Buttons
-
-Sprint 10: Mobile UX & Production OAuth ✅ (Complete)
-├── ✅ Mobile Navigation Menu
-│   ├── Hamburger button (visible on mobile only)
-│   ├── Slide-out navigation panel
-│   ├── Active route highlighting
-│   └── Body scroll lock when open
-├── ✅ OAuth Production Setup
-│   ├── Separate OAuth apps for dev/prod
-│   ├── trustHost config for Vercel proxy
-│   ├── Fixed env variable newline issues
-│   └── OAuth Vercel Setup Documentation
-├── ✅ Code Quality Improvements
-│   ├── Import ordering (alphabetized)
-│   ├── Updated MCP documentation
-│   └── .gitignore updates
-└── ✅ tRPC Session-Based Auth Migration
-```
-
----
-
-## 5. Technical Architecture
-
-### Stack Decisions
-
-| Layer          | Technology                            | Why                                             |
-| -------------- | ------------------------------------- | ----------------------------------------------- |
-| **Framework**  | Next.js 16 (App Router)               | Server Components, Server Actions, great DX     |
-| **Language**   | TypeScript                            | Type safety, better tooling, portfolio standard |
-| **Styling**    | Tailwind CSS 4 + Shadcn/ui            | Rapid development, consistent design            |
-| **Database**   | PostgreSQL (Neon)                     | Production-ready locally + in Vercel            |
-| **ORM**        | Prisma                                | Type-safe queries, easy migrations              |
-| **AI**         | Multi-provider (Gemini/OpenAI/Claude) | Flexibility, cost optimization                  |
-| **Hosting**    | Vercel                                | Native Next.js support, free tier               |
-| **DB Hosting** | Neon                                  | Serverless PostgreSQL, connection pooling       |
-
-### Design System
+## 5. Design System
 
 **Nordic Design** — Clean, professional, minimalist:
 
@@ -237,275 +90,31 @@ Sprint 10: Mobile UX & Production OAuth ✅ (Complete)
 - Typography: Clear hierarchy, readable
 - Components: Consistent spacing, accessible
 
-### Data Models
+---
 
-The schema has evolved beyond the MVP examples above (NextAuth models, CV file fields, social integrations).
+## 6. Out of Scope
 
-**Canonical source of truth:** `prisma/schema.prisma`
+Features intentionally excluded from portfolio scope:
 
-At a high level:
-
-- `User` (profile + CV content + auth metadata)
-- `Application` (tracker data + analysis + cover letter)
-- NextAuth models (`Account`, `Session`, `VerificationToken`)
-- Social integration models (`SocialProfile`, `SocialSync`, etc.)
+- Multi-provider OAuth (Google, LinkedIn)
+- Social integrations (GitHub/LinkedIn data sync)
+- Paid AI providers (OpenAI, Claude)
+- Interview calendar integration
+- Email notifications
+- Mobile native app
 
 ---
 
-## 6. Data Sources & Context
+## 7. Success Metrics
 
-The app's intelligence comes from understanding the user through multiple data sources:
-
-### GitHub Integration (v1.1)
-
-| Data Source    | What We Learn                       | How It Helps                                                 |
-| -------------- | ----------------------------------- | ------------------------------------------------------------ |
-| Repositories   | Actual projects built               | "You built X with React — mention it for this frontend role" |
-| Languages      | Real tech stack (not self-reported) | Accurate skill matching vs job requirements                  |
-| Contributions  | Activity patterns, open source      | Shows commitment, collaboration style                        |
-| README quality | Communication skills                | Writing samples inform cover letter tone                     |
-| Commit history | Work style, recent activity         | Demonstrates consistency and growth                          |
-
-### LinkedIn Integration (v1.1)
-
-| Data Source     | What We Learn               | How It Helps                           |
-| --------------- | --------------------------- | -------------------------------------- |
-| Profile         | Public professional persona | Detect CV ↔ LinkedIn mismatches       |
-| Saved jobs      | Jobs user is interested in  | Auto-populate tracker candidates       |
-| Connections     | Network at target companies | "You know 3 people at Company X"       |
-| Recommendations | Social proof, endorsements  | Extract quotes for cover letters       |
-| Activity/Posts  | Engagement style            | Match tone to their professional voice |
-
-### CV Import (v1.0)
-
-| Data Source    | What We Learn                | How It Helps                   |
-| -------------- | ---------------------------- | ------------------------------ |
-| Work history   | Roles, companies, dates      | Core experience for matching   |
-| Skills section | Self-reported abilities      | Compare against GitHub reality |
-| Education      | Degrees, certifications      | Qualification matching         |
-| Summary        | How they describe themselves | Tone and positioning           |
-
-### Multi-Source Intelligence
-
-When all sources are connected, the app can:
-
-- **Cross-validate skills** — GitHub shows React, CV says React, LinkedIn confirms React
-- **Detect gaps** — "Your GitHub shows Python, but it's not on your CV"
-- **Suggest improvements** — "Add your open-source contributions to LinkedIn"
-- **Generate accurate content** — Cover letters based on real projects, not just claims
+| Metric                | Target            |
+| --------------------- | ----------------- |
+| Core features working | 6/6 ✅            |
+| Production deployment | Live on Vercel ✅ |
+| Page load time        | < 3 seconds       |
+| Mobile responsive     | All pages ✅      |
+| Zero critical bugs    | Achieved ✅       |
 
 ---
 
-## 7. Cloud Infrastructure Roadmap
-
-### Current State (MVP)
-
-| Component           | Current Solution           | Status     | Risk Level |
-| ------------------- | -------------------------- | ---------- | ---------- |
-| **AI Extraction**   | Gemini Vision (AI Studio)  | ✅ Working | 🟢 Low     |
-| **PDF Compilation** | latexonline.cc (3rd party) | ✅ Working | 🟡 Medium  |
-| **File Storage**    | Vercel Blob                | ✅ Working | 🟢 Low     |
-| **Hosting**         | Vercel Serverless          | ✅ Working | 🟢 Low     |
-
-### Why This Matters
-
-**latexonline.cc Risk:**
-
-- No Data Processing Agreement (DPA)
-- Unknown logging/retention policies
-- Third-party dependency with no SLA
-- **GDPR concern:** User CV data sent to uncontrolled service
-
-**Current Decision:** Keep for development/testing. Replace before production launch with paying users.
-
-### Cloud Migration Plan (When Scaling)
-
-#### Phase 1: Self-Hosted LaTeX Compilation (Priority)
-
-**Problem:** `latexonline.cc` is a GDPR risk and has no SLA.
-
-**Solution:** Deploy `latex-online` Docker image to Google Cloud Run.
-
-**Why Cloud Run:**
-
-- Uses your £227 GCP credits (expires March 2026)
-- Scales to zero (pay only for usage)
-- Same API as latexonline.cc (drop-in replacement)
-- Full control over data processing
-- ~£5-10/month at moderate usage
-
-**Implementation:**
-
-```bash
-# 1. Deploy the Docker image
-gcloud run deploy latex-compiler \
-  --image aslushnikov/latex-online \
-  --platform managed \
-  --region europe-west2 \
-  --allow-unauthenticated \
-  --memory 2Gi \
-  --timeout 60
-
-# 2. Update environment variable
-LATEX_API_URL=https://latex-compiler-xxx.run.app
-```
-
-**Code Change Required:**
-
-```typescript
-// lib/latex-compiler.ts
-const LATEX_COMPILE_API = process.env.LATEX_API_URL || "https://latexonline.cc/compile";
-```
-
-#### Phase 2: Vertex AI (If Rate Limited)
-
-**Problem:** AI Studio free tier has 20 requests/day limit.
-
-**Solution:** Switch to Vertex AI (uses GCP credits, no daily limit).
-
-**When to migrate:**
-
-- If you consistently hit 20 requests/day
-- If you need higher rate limits for testing
-- Before launching to multiple users
-
-**Why Vertex AI over AI Studio:**
-
-- Same Gemini models
-- Pay-per-use (covered by credits)
-- No daily request limits
-- Enterprise SLA and support
-
-**Cost Estimate:** ~£10-20/month for moderate CV processing.
-
-#### Phase 3: Google Document AI (Optional)
-
-**Problem:** Text extraction from complex CV layouts.
-
-**Solution:** Document AI for structured text extraction.
-
-**When to consider:**
-
-- If Gemini Vision struggles with specific CV formats
-- If you need better table/column extraction
-- For enterprise-grade document processing
-
-**Why Document AI:**
-
-- Purpose-built for document understanding
-- Better structure preservation (tables, columns)
-- GDPR compliant (Google Cloud DPA)
-
-**Cost Estimate:** ~£0.001/page (covered by credits).
-
-### Decision Framework
-
-| Trigger                              | Action                           |
-| ------------------------------------ | -------------------------------- |
-| Ready to launch premium features     | Deploy Cloud Run LaTeX service   |
-| Hitting 20 requests/day on AI Studio | Switch to Vertex AI              |
-| Complex CV extraction issues         | Evaluate Document AI             |
-| AWS credits available                | Consider Textract as alternative |
-
-### Google Cloud Credits Usage Plan
-
-**Total Credits:** £227 (expires March 2026)
-
-| Service            | Monthly Estimate | Priority             |
-| ------------------ | ---------------- | -------------------- |
-| Cloud Run (LaTeX)  | £5-10            | 🔴 High (GDPR)       |
-| Vertex AI (Gemini) | £10-20           | 🟡 Medium            |
-| Document AI        | £5-10            | 🟢 Low               |
-| **Total**          | ~£20-40/month    | ~6-12 months covered |
-
-### Alternative: AWS Services
-
-If AWS credits become available:
-
-| Service          | Use Case                          | Free Tier         |
-| ---------------- | --------------------------------- | ----------------- |
-| **AWS Textract** | Document text extraction          | 1,000 pages/month |
-| **AWS Lambda**   | LaTeX compilation (via container) | 1M requests/month |
-| **S3**           | File storage                      | 5GB               |
-
-**Note:** AWS adds complexity (another cloud provider). Prefer GCP since credits are already available.
-
----
-
-## 8. Roadmap (Post v1.1)
-
-This section is the product-facing view. For execution-focused milestones and definitions of done, see `docs/ROADMAP.md`.
-
-### v1.2 (Draft) — Privacy, Reliability, Polish
-
-| Milestone | Goal                                               | Why it matters                        |
-| --------- | -------------------------------------------------- | ------------------------------------- |
-| M1        | Replace `latexonline.cc` compilation in production | GDPR + reliability risk reduction     |
-| M2        | Make CV blob storage private + signed downloads    | Reduce accidental PII exposure        |
-| M3        | Security & abuse hardening                         | Safer to share publicly / scale usage |
-| M4        | UX + performance polish                            | Better repeat usage, less friction    |
-
-### v1.3 (Draft) — Enhancements
-
-- Calendar integration for interviews
-- Follow-up reminders
-- Premium CV editor gating (depends on v1.2 LaTeX migration)
-
-### v2.0 (Ideas) — Advanced
-
-- Interview prep module
-- Salary negotiation helper
-- Multi-user + teams
-- Browser extension
-
----
-
-## 9. Success Metrics
-
-### v1.0 Launch Criteria
-
-| Metric                | Target         |
-| --------------------- | -------------- |
-| Core features working | 6/6 complete   |
-| Production deployment | Live on Vercel |
-| Page load time        | < 3 seconds    |
-| Mobile responsive     | All pages      |
-| Zero critical bugs    | 0 blockers     |
-
-### User Success
-
-- [ ] Faster job applications (< 10 min per application)
-- [ ] Better cover letter quality
-- [ ] Never forget an application again
-- [ ] Clear view of job search progress
-
----
-
-## 10. Open Questions
-
-1. **CV parsing accuracy** — How do we handle poorly formatted CVs?
-2. **AI cost management** — Rate limiting for Gemini free tier?
-3. **Data privacy** — How long to retain job descriptions?
-4. **Offline support** — Is it needed for v1.0?
-5. **OAuth scopes** — What minimal permissions do we need for GitHub/LinkedIn?
-6. **Rate limits** — How often can we sync from GitHub/LinkedIn APIs?
-7. **Data freshness** — How often to re-sync external data?
-
----
-
-## Changelog
-
-| Date         | Doc Revision | Changes                                                          |
-| ------------ | ------------ | ---------------------------------------------------------------- |
-| Dec 6, 2025  | 0.1          | Initial draft                                                    |
-| Dec 6, 2025  | 0.2          | Elevated GitHub/LinkedIn to v1.1, added Data Sources section     |
-| Dec 7, 2025  | 1.0          | **MVP Complete** - All P0 features done, deployed to Vercel      |
-| Dec 8, 2025  | 1.1          | **CV Editor** - LaTeX editor, 3 templates, multi-model AI        |
-| Dec 8, 2025  | 1.2          | **Cloud Roadmap** - Added infrastructure roadmap for GCP/scaling |
-| Dec 8, 2025  | 1.3          | **UX Research** - Added /docs/ux/ and /admin/ux-planner          |
-| Dec 9, 2025  | 1.4          | **v1.1 Complete** - Auth, Social Integrations, GitHub/LinkedIn   |
-| Dec 12, 2025 | 1.5          | Clarified roadmap + doc versioning, synced stack notes           |
-
----
-
-_This is a living document. Update as the product evolves._
+_This is a portfolio project demonstrating full-stack TypeScript and AI integration skills._

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,91 +2,95 @@
 
 This roadmap is the execution-focused companion to the PRD.
 
-- Current release: **v1.1** (shipped)
-- Next release target: **v1.2** (draft)
+- Current release: **v1.2** (in progress)
+- Focus: Portfolio polish and simplification
 
 ---
 
-## v1.2 (Draft) — Privacy, Reliability, Polish
+## v1.2 — Portfolio Polish
 
-### Milestone 1 — Replace LaTeX Third-Party Compiler (GDPR)
+### Milestone 1 — Auth Simplification ✅
 
-**Goal:** Stop sending CV LaTeX to `latexonline.cc` by default.
+**Goal:** Simplify authentication to GitHub OAuth only.
 
 **Deliverables:**
 
-- Deploy a self-hosted LaTeX compiler service (e.g., Docker on Cloud Run)
-- Configure the app to use an environment variable for the compiler base URL
-- Document data flow + retention expectations for compilation
+- Remove Google and LinkedIn OAuth providers
+- Keep GitHub OAuth for developer-friendly sign-in
+- Email/password auth (planned)
 
-**Definition of Done:**
-
-- The compiler endpoint is controlled by us (self-hosted) in production
-- Compilation works with the existing CV templates and common CV sizes
-- A rollback switch exists (env var) if the self-hosted service is degraded
+**Status:** Complete
 
 ---
 
-### Milestone 2 — Storage Privacy (CV Files)
+### Milestone 2 — AI Simplification ✅
 
-**Goal:** Reduce accidental exposure risk for CV uploads/compiled PDFs.
+**Goal:** Use only free-tier AI models.
 
 **Deliverables:**
 
-- Move sensitive CV blobs to private access (or equivalent)
-- Provide time-limited signed URLs for downloads/previews
+- Remove OpenAI and Claude (paid) providers
+- Keep Gemini 2.5 Flash (free)
+- Keep OpenRouter free models (Gemma, Nova, Mistral)
 
-**Definition of Done:**
-
-- CV files are not publicly accessible by default
-- Users can still view/download their CV from the UI without regressions
+**Status:** Complete
 
 ---
 
-### Milestone 3 — Security & Abuse Hardening
+### Milestone 3 — UI Cleanup ✅
 
-**Goal:** Ensure the app is safe to expose beyond a single-user portfolio.
+**Goal:** Clean navigation for portfolio demo.
 
 **Deliverables:**
 
-- Review all `publicProcedure` usage and lock down anything user-scoped
-- Improve rate limiting strategy for distributed/serverless execution (if needed)
-- Confirm production fails fast without required secrets (no insecure fallbacks)
+- Hide Admin from navigation (accessible by URL)
+- Simplify Settings page (account only)
+- Remove integrations UI
 
-**Definition of Done:**
-
-- All user data routes require auth + are scoped to the authenticated user
-- Rate limiting is enforced for AI + upload paths in production
-- Missing production secrets cause startup/runtime failures rather than insecure defaults
+**Status:** Complete
 
 ---
 
-### Milestone 4 — UX + Performance Polish
+### Milestone 4 — CV Editor Polish (Planned)
 
-**Goal:** Make the core flow feel effortless on repeat usage.
+**Goal:** Make the LaTeX CV editor the star feature.
 
 **Deliverables:**
 
-- Reduce friction in the “upload → extract → edit → analyze” loop
-- Tighten UI consistency across pages (design-system audit)
-- Bundle size / client JS audit to keep navigation snappy
+- Add syntax highlighting (Monaco or CodeMirror)
+- Improve error messages for LaTeX compilation
+- Better mobile experience
 
-**Definition of Done:**
-
-- Primary user journey feels consistent and fast on mobile + desktop
-- No regressions to existing v1.1 features
+**Status:** Planned
 
 ---
 
-## v1.3 (Draft) — Enhancements
+### Milestone 5 — Documentation (In Progress)
 
-- Calendar integration for interviews
-- Follow-up reminders
-- Premium CV editor gating (requires v1.2 LaTeX migration)
+**Goal:** Portfolio-focused documentation.
+
+**Deliverables:**
+
+- Updated README with skills showcase
+- Simplified PRD
+- Screenshots of key flows
+
+**Status:** In Progress
+
+---
+
+## Future Considerations
+
+These features are out of scope for the portfolio but could be added later:
+
+- Email/password authentication
+- PDF export improvements
+- Interview calendar integration
+- Job board integrations
 
 ---
 
 ## Notes
 
 - For context and rationale, see the PRD: `docs/PRD.md`.
-- For security backlog framing, see: `docs/SECURITY_AUDIT.md`.
+- This is a portfolio project, not a production SaaS.


### PR DESCRIPTION
## Summary
Rewrites project documentation to focus on portfolio presentation rather than production-scale ambitions.

## Changes

### README.md
- Complete rewrite as portfolio showcase
- Added "What This Demonstrates" skills section
- Simplified tech stack presentation
- Removed complex deployment instructions

### docs/PRD.md  
- Reduced from 500+ lines to ~100 lines
- Removed: cloud infrastructure, enterprise features, scaling plans
- Kept: core features, tech stack, design system basics

### docs/ROADMAP.md
- Simplified to 3 milestones (Done, Polish, Quality)
- Removed: Cloud Run, Vertex AI, multi-provider integrations
- Focus on completing portfolio polish

## Closes
- Closes #105 (Update README)
- Closes #106 (Update ROADMAP)  
- Closes #107 (Update PRD)